### PR TITLE
Use existing descending trendline rule module

### DIFF
--- a/test_descending_trendline_breakthrough.py
+++ b/test_descending_trendline_breakthrough.py
@@ -160,7 +160,9 @@ def descending_trendline_test(stock_id='2330', days=360):
     try:
         # 導入必要模塊
         from src.validate_buy_rule import load_stock_data
-        from src.buyRule.breakthrough_descending_trendline_buy_rule import check_breakthrough_descending_trendline_buy_rule
+        from src.buyRule.breakthrough_descending_trendline import (
+            check_breakthrough_descending_trendline_buy_rule,
+        )
         from src.baseRule.turning_point_identification import identify_turning_points
         
         # 載入數據


### PR DESCRIPTION
## Summary
- update the descending trendline test script to import the existing buy rule implementation
- remove the redundant compatibility wrapper module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d630c069208333ba854b9321258b8c